### PR TITLE
Uppercase arch before pushing it to *features*

### DIFF
--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2499,7 +2499,7 @@ public final class Lisp
         featureList = featureList.push(Keyword.X86);
       } else {
         // just push the value of 'os.arch' as a keyword
-        featureList = featureList.push(internKeyword(osArch));
+        featureList = featureList.push(internKeyword(osArch.toUpperCase()));
       }
     }
 


### PR DESCRIPTION
Noticed that ABCL on ARM64 showed up as `:|aarch64|` on `*features*`